### PR TITLE
[PR] hr_work_entry_attendances: add missing definition of images in __manifest__

### DIFF
--- a/hr_work_entry_attendances/__manifest__.py
+++ b/hr_work_entry_attendances/__manifest__.py
@@ -27,7 +27,7 @@
             'hr_work_entry_attendances/static/src/xml/gantt_renderer.xml'
         ],
     },
-    'images': [],
+    'images': ['static/description/banner.png'],
     'license': 'LGPL-3',
     'installable': True,
     'auto_install': False,


### PR DESCRIPTION
[[FIX] hr_work_entry_attendances: add missing definition of images in __manifest__](https://github.com/ltrthanhdev/hr_work_entry_attendances/commit/a0f9b879fa251a7f496cb593294a89462a39db3b)